### PR TITLE
Add support for blanks in assertions

### DIFF
--- a/lib/blank_assertions.ex
+++ b/lib/blank_assertions.ex
@@ -1,0 +1,48 @@
+defmodule BlankAssertions do
+  defmacro assert(expr) do
+    if contains_blank?(expr) do
+      code = Macro.escape(expr)
+      quote do
+        raise ExUnit.AssertionError, expr: unquote(code)
+      end
+    else
+      quote do
+        ExUnit.Assertions.assert(unquote(expr))
+      end
+    end
+  end
+
+  defmacro refute(expr) do
+    if contains_blank?(expr) do
+      code = Macro.escape(expr)
+      quote do
+        raise ExUnit.AssertionError, expr: unquote(code)
+      end
+    else
+      quote do
+        ExUnit.Assertions.refute(unquote(expr))
+      end
+    end
+  end
+
+  def assert(value, opts) do
+    ExUnit.Assertions.assert(value, opts)
+  end
+
+  defp contains_blank?(expr) do
+    {_, blank} = Macro.prewalk(expr, false, &blank?/2)
+    blank
+  end
+
+  defp blank?(node, true) do
+    {node, true}
+  end
+
+  defp blank?({expr, _, _} = node, _acc) do
+    {node, expr == :__}
+  end
+
+  defp blank?(expr, _acc) do
+    {expr, expr == :__}
+  end
+end

--- a/lib/koans.ex
+++ b/lib/koans.ex
@@ -18,7 +18,8 @@ defmodule Koans do
   defmacro __using__(_) do
     quote do
       import Koans
-      import ExUnit.Assertions
+      require ExUnit.Assertions
+      import BlankAssertions
     end
   end
 


### PR DESCRIPTION
This is done by wrapping the ExUnit assertions that we use. Instead of calling ExUnit straight, the `BlankAssertions` module intercepts calls and does one of two things:

  * If the assertion contains a blank, it is failed immediately. ExUnit is never called and the failing expression is printed
  * If the assertions does not contain a blank, just delegates to ExUnit and lets it handle the assertion.